### PR TITLE
Fix panics on assigning

### DIFF
--- a/cmd/ic-assignment/main.go
+++ b/cmd/ic-assignment/main.go
@@ -62,6 +62,14 @@ func main() {
 		log.Fatalf("Unable to parse config: %v", err)
 	}
 
+	if actionCtx.Issue == nil {
+		log.Fatalf("Unable to run without an issue set")
+	}
+
+	if actionCtx.Issue.Number == nil {
+		log.Fatalf("No issue number is set")
+	}
+
 	dryRun := githubaction.GetInputOrDefault("dry-run", "true") != "false"
 
 	action := &icassigner.Action{

--- a/pkg/icassigner/action.go
+++ b/pkg/icassigner/action.go
@@ -140,7 +140,15 @@ func (a *Action) Run(ctx context.Context, event *github.IssuesEvent, dryRun bool
 		return nil
 	}
 
-	_, _, err = a.Client.Issues.AddAssignees(ctx, *event.Issue.Repository.Owner.Name, *event.Issue.Repository.Name, *event.Issue.Number, []string{theChosenOne.Name})
+	if event.Issue.Repository == nil || event.Issue.Repository.Name == nil {
+		log.Fatalf("Can't set any assignee as the repository or its name is missing, payload: %+v", event.Issue.Repository)
+	}
+
+	if event.Issue.Repository.Owner == nil || event.Issue.Repository.Owner.Login == nil {
+		log.Fatalf("Can't set any assignee as the repository owner or its login name is missing, payload: %+v", event.Issue.Repository.Owner)
+	}
+
+	_, _, err = a.Client.Issues.AddAssignees(ctx, *event.Issue.Repository.Owner.Login, *event.Issue.Repository.Name, *event.Issue.Number, []string{theChosenOne.Name})
 
 	return err
 }


### PR DESCRIPTION
Fix panic by not using the repository owner name when assigning an escalation.