### PR TITLE
check github login instead of name

### DIFF
--- a/ic-assignment/action.yml
+++ b/ic-assignment/action.yml
@@ -21,4 +21,4 @@ outputs:
     description: "The output property of the assigned person. If output property is empty, name is used instead"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.11"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.12"

--- a/pkg/icassigner/action.go
+++ b/pkg/icassigner/action.go
@@ -59,7 +59,7 @@ func (a *Action) Run(ctx context.Context, event *github.IssuesEvent, dryRun bool
 	// check if someone from the team is already assigned (skip in this case)
 	for _, m := range teamMembers {
 		for _, a := range event.Issue.Assignees {
-			if a.GetName() == m.Name {
+			if a.GetLogin() == m.Name {
 				log.Printf("Found assignee %q which is member of the matched team %q. Stopping\n", m.Name, teamName)
 				return nil
 			}

--- a/regex-labeler/action.yml
+++ b/regex-labeler/action.yml
@@ -9,4 +9,4 @@ inputs:
     description: "GitHub token to use for API calls"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.11"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.12"


### PR DESCRIPTION
The check to prevent that multiple people get assigned to the same issue is broken, in [this run](https://github.com/grafana/support-escalations/actions/runs/9272899351/job/25511754109) a second person has been assigned even though somebody was already assigned.