### PR TITLE
Make team member busyness calculation more verbose

### DIFF
--- a/ic-assignment/action.yml
+++ b/ic-assignment/action.yml
@@ -21,4 +21,4 @@ outputs:
     description: "The output property of the assigned person. If output property is empty, name is used instead"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.12"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.13"

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -174,7 +174,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 				log.Printf("%s: Issue doesn't increase busyiness because it has been closed at %s which is before %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 			}
 		default:
-			log.Printf("%s: Issue doesn't increase busyiness because it has an unknown state (%s): %s\n", member, i.GetState(), i.GetTitle())
+			log.Printf("%s: Issue doesn't increase busyness because it has an unknown state (%s): %s\n", member, i.GetState(), i.GetTitle())
 		}
 	}
 

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -171,7 +171,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 				log.Printf("%s: Issue increases busyness because it has been closed at %s which is after %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 				busyness++
 			} else {
-				log.Printf("%s: Issue doesn't increase busyiness because it has been closed at %s which is before %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
+				log.Printf("%s: Issue doesn't increase busyness because it has been closed at %s which is before %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 			}
 		default:
 			log.Printf("%s: Issue doesn't increase busyness because it has an unknown state (%s): %s\n", member, i.GetState(), i.GetTitle())

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -163,7 +163,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 			}
 
 			// increase busyness count otherwise
-			log.Printf("Issue increases busyiness because it is still open: %s\n", i.GetTitle())
+			log.Printf("%s: Issue increases busyiness because it is still open: %s\n", member, i.GetTitle())
 			busyness++
 		case "closed":
 			// if the issue got closed since our time to check

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -144,7 +144,7 @@ func newGithubBusynessClient(githubClient *github.Client, ignorableLabels []stri
 func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time, member string) int {
 	// check if one of the labels is contained by the labels to ignore
 
-	log.Printf("Listing issues of member %s since %s\n", member, since.String())
+	log.Printf("Calculating busyness of member %s based on their issues since %s\n", member, since.String())
 
 	issues, err := b.listByAssigneeFunc(ctx, since, member, 20)
 	if err != nil {
@@ -158,7 +158,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 		case "open":
 			// check for labels to ignore, e.g. `stale` and ignore issue in this case
 			if b.containsLabelsToIgnore(i.Labels) {
-				log.Printf("Ignoring open issue because it contains labels to ignore (%s): %s\n", labelsToString(i.Labels), i.GetTitle())
+				log.Printf("%s: Ignoring open issue because it contains labels to ignore (%s): %s\n", member, labelsToString(i.Labels), i.GetTitle())
 				continue
 			}
 
@@ -168,13 +168,13 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 		case "closed":
 			// if the issue got closed since our time to check
 			if since.Before(i.GetClosedAt()) {
-				log.Printf("Issue increases busyiness because it has been closed at %s which is after %s: %s\n", i.GetClosedAt().String(), since.String(), i.GetTitle())
+				log.Printf("%s: Issue increases busyiness because it has been closed at %s which is after %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 				busyness++
 			} else {
-				log.Printf("Issue doesn't increase busyiness because it has been closed at %s which is before %s: %s\n", i.GetClosedAt().String(), since.String(), i.GetTitle())
+				log.Printf("%s: Issue doesn't increase busyiness because it has been closed at %s which is before %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 			}
 		default:
-			log.Printf("Issue doesn't increase busyiness because it has an unknown state (%s): %s\n", i.GetState(), i.GetTitle())
+			log.Printf("%s: Issue doesn't increase busyiness because it has an unknown state (%s): %s\n", member, i.GetState(), i.GetTitle())
 		}
 	}
 

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -56,7 +56,7 @@ type busynessClient interface {
 
 // CalculateBusynessForTeam calculates busyness of all members and returns a BusynessReport for them
 func CalculateBusynessForTeam(ctx context.Context, now time.Time, githubClient *github.Client, ignorableLabels []string, members []string) (Report, error) {
-	log.Printf("Calculating issue busyness for team members: %s\n", strings.Join(members, ", "))
+	log.Printf("Calculating busyness for team members: %s\n", strings.Join(members, ", "))
 
 	bA, err := newGithubBusynessClient(githubClient, ignorableLabels)
 	if err != nil {

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -163,7 +163,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 			}
 
 			// increase busyness count otherwise
-			log.Printf("%s: Issue increases busyiness because it is still open: %s\n", member, i.GetTitle())
+			log.Printf("%s: Issue increases busyness because it is still open: %s\n", member, i.GetTitle())
 			busyness++
 		case "closed":
 			// if the issue got closed since our time to check

--- a/pkg/icassigner/busyness/busyness.go
+++ b/pkg/icassigner/busyness/busyness.go
@@ -168,7 +168,7 @@ func (b *githubBusynessClient) getBusyness(ctx context.Context, since time.Time,
 		case "closed":
 			// if the issue got closed since our time to check
 			if since.Before(i.GetClosedAt()) {
-				log.Printf("%s: Issue increases busyiness because it has been closed at %s which is after %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
+				log.Printf("%s: Issue increases busyness because it has been closed at %s which is after %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())
 				busyness++
 			} else {
 				log.Printf("%s: Issue doesn't increase busyiness because it has been closed at %s which is before %s: %s\n", member, i.GetClosedAt().String(), since.String(), i.GetTitle())

--- a/regex-labeler/action.yml
+++ b/regex-labeler/action.yml
@@ -9,4 +9,4 @@ inputs:
     description: "GitHub token to use for API calls"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.12"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.13"


### PR DESCRIPTION
We need better insight into how each team member's busyness gets calculated to understand how it comes to its conclusion and whether it is fair.

Related: [Slack thread](https://raintank-corp.slack.com/archives/C029912SXT8/p1717004141459399)