### PR TITLE
rename required_labels to requireLabel

### DIFF
--- a/ic-assignment/action.yml
+++ b/ic-assignment/action.yml
@@ -21,4 +21,4 @@ outputs:
     description: "The output property of the assigned person. If output property is empty, name is used instead"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.13"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-ic-assignment:v0.14"

--- a/pkg/labeler/config.go
+++ b/pkg/labeler/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	// The label with the highest score is applied to the issue.
 	Labels map[string]Label `yaml:"labels,omitempty"`
 
-	// RequireLabel is a list of labels that must be present on the issue for any other labels to be applied.
+	// RequireLabel is a list of labels, for the regex-labeler to run at least one of the specified labels must be present on the issue.
 	RequireLabel []string `yaml:"requireLabel,omitempty"`
 }
 

--- a/pkg/labeler/config.go
+++ b/pkg/labeler/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	// The label with the highest score is applied to the issue.
 	Labels map[string]Label `yaml:"labels,omitempty"`
 
-	// RequiredLabels is a list of labels that must be present on the issue for any other labels to be applied.
-	RequiredLabels []string `yaml:"required_labels,omitempty"`
+	// RequireLabel is a list of labels that must be present on the issue for any other labels to be applied.
+	RequireLabel []string `yaml:"requireLabel,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/pkg/labeler/labeler.go
+++ b/pkg/labeler/labeler.go
@@ -47,7 +47,7 @@ func (l *Labeler) Run(issue *github.Issue) error {
 		return nil
 	}
 
-	level.Info(l.logger).Log("msg", "issue has the required labels", "required_labels", strings.Join(l.cfg.RequiredLabels, ", "))
+	level.Info(l.logger).Log("msg", "issue has the required labels", "required_labels", strings.Join(l.cfg.RequireLabel, ", "))
 
 	if l.hasAssignableLabel(issue) {
 		return nil
@@ -155,7 +155,7 @@ func (l *Labeler) hasAssignableLabel(issue *github.Issue) bool {
 func (l *Labeler) hasRequiredLabels(issue *github.Issue) bool {
 	issueLabels := getIssueLabels(issue)
 
-	for _, requiredLabel := range l.cfg.RequiredLabels {
+	for _, requiredLabel := range l.cfg.RequireLabel {
 		if !slices.Contains[[]string, string](issueLabels, requiredLabel) {
 			level.Info(l.logger).Log("msg", "issue is missing required label", "label", requiredLabel)
 			return false

--- a/pkg/labeler/labeler.go
+++ b/pkg/labeler/labeler.go
@@ -155,12 +155,17 @@ func (l *Labeler) hasAssignableLabel(issue *github.Issue) bool {
 func (l *Labeler) hasRequiredLabels(issue *github.Issue) bool {
 	issueLabels := getIssueLabels(issue)
 
+	match := false
 	for _, requiredLabel := range l.cfg.RequireLabel {
-		if !slices.Contains[[]string, string](issueLabels, requiredLabel) {
-			level.Info(l.logger).Log("msg", "issue is missing required label", "label", requiredLabel)
-			return false
+		if slices.Contains[[]string, string](issueLabels, requiredLabel) {
+			match = true
 		}
+
 	}
 
-	return true
+	if !match {
+		level.Info(l.logger).Log("msg", "issue has none of the required labels", "requireLabel", strings.Join(l.cfg.RequireLabel, ","))
+	}
+
+	return match
 }

--- a/pkg/labeler/labeler.go
+++ b/pkg/labeler/labeler.go
@@ -44,10 +44,11 @@ func NewLabeler(cfg Config, gh *github.Client, logger log.Logger) *Labeler {
 
 func (l *Labeler) Run(issue *github.Issue) error {
 	if !l.hasRequiredLabels(issue) {
+		level.Info(l.logger).Log("msg", "issue has none of the required labels", "requireLabel", strings.Join(l.cfg.RequireLabel, ", "))
 		return nil
 	}
 
-	level.Info(l.logger).Log("msg", "issue has the required labels", "required_labels", strings.Join(l.cfg.RequireLabel, ", "))
+	level.Info(l.logger).Log("msg", "issue has at least one of the required labels", "requireLabel", strings.Join(l.cfg.RequireLabel, ", "))
 
 	if l.hasAssignableLabel(issue) {
 		return nil
@@ -161,10 +162,6 @@ func (l *Labeler) hasRequiredLabels(issue *github.Issue) bool {
 			match = true
 		}
 
-	}
-
-	if !match {
-		level.Info(l.logger).Log("msg", "issue has none of the required labels", "requireLabel", strings.Join(l.cfg.RequireLabel, ","))
 	}
 
 	return match

--- a/pkg/labeler/labeler_test.go
+++ b/pkg/labeler/labeler_test.go
@@ -42,7 +42,7 @@ func TestAssigningLabel(t *testing.T) {
 		{
 			name: "assign the mimir-query label",
 			cfg: Config{
-				RequireLabel: []string{"label1"},
+				RequireLabel: []string{"label1", "label3"},
 				Labels: map[string]Label{
 					"mimir-ingest": {
 						Matchers: []Matcher{

--- a/pkg/labeler/labeler_test.go
+++ b/pkg/labeler/labeler_test.go
@@ -78,6 +78,32 @@ func TestAssigningLabel(t *testing.T) {
 				issueNumber: testIssueNumber,
 				labels:      []string{"label1", "label2", "mimir-query"},
 			}},
+		}, {
+			name: "don't assign label due to lack of required labels",
+			cfg: Config{
+				RequireLabel: []string{"label1", "label2"},
+				Labels: map[string]Label{
+					"mimir-query": {
+						Matchers: []Matcher{
+							{
+								regex:  regexp.MustCompile(`.*`),
+								Weight: 1,
+							},
+						},
+					},
+				},
+			},
+			issue: &github.Issue{
+				Number:        &testIssueNumber,
+				Title:         github.String("some title"),
+				Body:          github.String("some body abc something something query more text."),
+				RepositoryURL: &testRepositoreURL,
+				Labels: []github.Label{
+					{Name: github.String("label3")},
+					{Name: github.String("label4")},
+				},
+			},
+			expectedLabelAssignerCalls: nil,
 		},
 	}
 

--- a/pkg/labeler/labeler_test.go
+++ b/pkg/labeler/labeler_test.go
@@ -42,6 +42,7 @@ func TestAssigningLabel(t *testing.T) {
 		{
 			name: "assign the mimir-query label",
 			cfg: Config{
+				RequireLabel: []string{"label1"},
 				Labels: map[string]Label{
 					"mimir-ingest": {
 						Matchers: []Matcher{

--- a/regex-labeler/action.yml
+++ b/regex-labeler/action.yml
@@ -9,4 +9,4 @@ inputs:
     description: "GitHub token to use for API calls"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.13"
+  image: "docker://ghcr.io/grafana/issue-team-scheduler-regex-labeler:v0.14"


### PR DESCRIPTION
This makes the name of the configuration flag in the `regex-labeler` consistent with the `ic-assigner`.