### PR TITLE
Do not panic if TZ parsing of iCal feed fails

### DIFF
--- a/pkg/icassigner/calendar/ical.go
+++ b/pkg/icassigner/calendar/ical.go
@@ -155,7 +155,7 @@ func CheckAvailability(icalUrl string, name string, now time.Time, unavailabilit
 	if tzString := cal.Props.Get("X-WR-TIMEZONE"); tzString != nil {
 		loc, err = time.LoadLocation(tzString.Value)
 		if err != nil {
-			log.Printf("Unable to parse timezone %q, due %v", tzString.Value, err)
+			return true, fmt.Errorf("unable to parse timezone %q, due %w", tzString.Value, err)
 		}
 	}
 


### PR DESCRIPTION
If parsing the time zone from the calendar feed fails, `loc` would be `nil` and therefore the subsequent call `checkEvents()` would fail with a panic, because the availability check requires the time.Location to be not `nil`.

```
goroutine 1 [running]:
time.Time.In(...)
	/usr/local/go/src/time/time.go:1167
github.com/grafana/escalation-scheduler/pkg/icassigner/calendar.(*icalAvailabilityChecker).isEventBlockingAvailability(0xc00015d588, {0x0?, 0xb484b9?, 0x0?}, {0xede56deb0?, 0x0?, 0x0?})
	/src/pkg/icassigner/calendar/ical.go:61 +0x232
github.com/grafana/escalation-scheduler/pkg/icassigner/calendar.checkEvents({0xc003d28000, 0x1897, 0xc00015d8b8?}, {0xc0002fdeb0, 0xd}, {0x0?, 0x0?, 0x10cf060?}, 0x0, 0x13a52453c000)
	/src/pkg/icassigner/calendar/ical.go:108 +0x2e5
github.com/grafana/escalation-scheduler/pkg/icassigner/calendar.CheckAvailability({0xc000337f80?, 0x10?}, {0xc0002fdeb0, 0xd}, {0x0?, 0x0?, 0x10cf060?}, 0x13a52453c000)
	/src/pkg/icassigner/calendar/ical.go:162 +0x6dc
github.com/grafana/escalation-scheduler/pkg/icassigner.checkAvailability({{0xc0002fdeb0, 0xd}, {0xc000337f80, 0x79}, {0x0, 0x0}, {0xc0002fded0, 0xb}}, 0x13a52453c000)
	/src/pkg/icassigner/action.go:181 +0x10d
github.com/grafana/escalation-scheduler/pkg/icassigner.(*Action).Run(0xc00015df00, {0xc45510, 0x11303c0}, 0xc0002aedc0, 0x1)
	/src/pkg/icassigner/action.go:99 +0xe1a
main.main()
	/src/cmd/ic-assignment/main.go:80 +0x4a5
```